### PR TITLE
Updating version number in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Add the necessary dependency to your project:
 
 ```clojure
-[com.taoensso/truss "1.1.0"]
+[com.taoensso/truss "1.1.1"]
 ```
 
 And setup your namespace imports:


### PR DESCRIPTION
Was passing this on to a colleague and we noticed the version number wasn't updated in the Quickstart. Figured I'd do a quick patch.
